### PR TITLE
Update CalculateGroupPath.R

### DIFF
--- a/R/CalculateGroupPath.R
+++ b/R/CalculateGroupPath.R
@@ -38,5 +38,6 @@ CalculateGroupPath <- function(df) {
   }
   # Make sure that name of first column matches that of input data (in case !="group")
   colnames(graphData)[1] <- colnames(df)[1]
+  graphData$group <- factor(graphData$group, levels=levels(df[, 1]) ) # keep group order
   graphData # data frame returned by function
 }


### PR DESCRIPTION
In present form the original levels information of the groups is lost when the group path radial x-y coordinates are calculated so ggplot always plots groups in alphabetical or numerical order. Added line 41 in CalculateGroupPath.R creates a factor with the same levels as original dataframe so initial group order is not lost.