### PR TITLE
Set legend position rather than theme if plot.legend is FALSE

### DIFF
--- a/R/ggradar.R
+++ b/R/ggradar.R
@@ -203,7 +203,7 @@ ggradar <- function(plot.data,
       legend.key = element_rect(linetype = "blank")
     )
 
-  if (plot.legend == FALSE) theme_clear <- theme_clear + theme(legend.position = "none")
+  if (plot.legend == FALSE) legend.position = "none"
 
   # Base-layer = axis labels + plot extent
   # [need to declare plot extent as well, since the axis labels don't always


### PR DESCRIPTION
Closes #17 

plot.legend = FALSE was not working because it was being overwritten by theming at line 307. Changing value of variable legend.position prevents this and restores the intended behavior. 