### PR TITLE
Add conditional to restore legend title when provided by user

### DIFF
--- a/R/ggradar.R
+++ b/R/ggradar.R
@@ -309,6 +309,10 @@ ggradar <- function(plot.data,
     scale_colour_manual(values = colour_values) +
     theme(text = element_text(family = font.radar)) +
     theme(legend.title = element_blank())
+  
+  if(legend.title != "") {
+     base <- base + theme(legend.title = element_text())
+   }
 
   if (plot.title != "") {
     base <- base + ggtitle(plot.title)


### PR DESCRIPTION
Closes #24 

When user provided title, theming at line 311 was suppressing the legend title. Added a conditional statement to display the legend title if it is not blank.  