### PR TITLE
Retain name of grouping variable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Authors@R:
 Description: This package exports the functionality of ggplot2 to create radar charts.
 License: GPL
 Imports:
+    forcats,
     ggplot2
 Suggests: 
     testthat (>= 2.1.0)

--- a/R/CalculateGroupPath.R
+++ b/R/CalculateGroupPath.R
@@ -9,35 +9,39 @@
 #' @source 
 #' Code adapted from a solution posted by Tony M to \url{http://stackoverflow.com/questions/9614433/creating-radar-chart-a-k-a-star-plot-spider-plot-using-ggplot2-in-r}.
 CalculateGroupPath <- function(df) {
-  path <- df[, 1]
+  # Drop dead levels. This might happen if the data is filtered on the way
+  # into ggradar.
+  path <- forcats::fct_drop(df[, 1])
+  # set the name of the variable that will be used for grouping
+  theGroupName <- colnames(df)[1]
   
   ## find increment
-  angles <- seq(from = 0, to = 2 * pi, by = (2 * pi) / (ncol(df) - 1))
+  nPathPoints <- ncol(df) - 1
+  angles <- seq(from = 0, to = 2 * pi, by = (2 * pi) / nPathPoints)
   ## create graph data frame
-  graphData <- data.frame(seg = "", x = 0, y = 0)
-  graphData <- graphData[-1, ]
-  
-  for (i in levels(path)) {
-    pathData <- subset(df, df[, 1] == i)
+  nDataPoints <- ncol(df) * length(levels(path))
+  graphData <- data.frame(
+                          seg = rep("",nDataPoints),
+                          x = rep(0, nDataPoints),
+                          y = rep(0, nDataPoints))
+  colnames(graphData)[1] <- theGroupName
+
+  rowNum <- 1
+  for (i in 1:length(levels(path))) {
+    pathData <- subset(df, df[, 1] == levels(path)[i])
     for (j in c(2:ncol(df))) {
-      # pathData[,j]= pathData[,j]
-      
-      
-      graphData <- rbind(graphData, data.frame(
-        group = i,
-        x = pathData[, j] * sin(angles[j - 1]),
-        y = pathData[, j] * cos(angles[j - 1])
-      ))
+      graphData[rowNum,theGroupName] <- levels(path)[i]
+      graphData$x[rowNum] <- pathData[, j] * sin(angles[j - 1])
+      graphData$y[rowNum] <- pathData[, j] * cos(angles[j - 1])
+      rowNum <- rowNum + 1
     }
     ## complete the path by repeating first pair of coords in the path
-    graphData <- rbind(graphData, data.frame(
-      group = i,
-      x = pathData[, 2] * sin(angles[1]),
-      y = pathData[, 2] * cos(angles[1])
-    ))
+    graphData[rowNum,theGroupName] <- levels(path)[i]
+    graphData$x[rowNum] <- pathData[, 2] * sin(angles[1])
+    graphData$y[rowNum] <- pathData[, 2] * cos(angles[1])
+    rowNum <- rowNum + 1
   }
   # Make sure that name of first column matches that of input data (in case !="group")
-  colnames(graphData)[1] <- colnames(df)[1]
-  graphData$group <- factor(graphData$group, levels=levels(df[, 1]) ) # keep group order
+  graphData[,1] <- factor(graphData[,1], levels=levels(path) ) # keep group order
   graphData # data frame returned by function
 }

--- a/R/ggradar.R
+++ b/R/ggradar.R
@@ -113,8 +113,6 @@ ggradar <- function(plot.data,
     plot.data[, 1] <- as.factor(as.character(plot.data[, 1]))
   }
 
-  names(plot.data)[1] <- "group"
-
   var.names <- colnames(plot.data)[-1] # Short version of variable names
   # axis.labels [if supplied] is designed to hold 'long version' of variable names
   # with line-breaks indicated using \n
@@ -267,18 +265,20 @@ ggradar <- function(plot.data,
     colour = axis.line.colour
   )
 
+  theGroupName <- names(group$path[1])
+
   # ... + group (cluster) 'paths'
   base <- base + geom_path(
-    data = group$path, aes(x = x, y = y, group = group, colour = group),
+    data = group$path, aes_string(x = "x", y = "y", group = theGroupName, colour = theGroupName),
     size = group.line.width
   )
 
   # ... + group points (cluster data)
-  base <- base + geom_point(data = group$path, aes(x = x, y = y, group = group, colour = group), size = group.point.size)
+  base <- base + geom_point(data = group$path, aes_string(x = "x", y = "y", group = theGroupName, colour = theGroupName), size = group.point.size)
 
   # ... + group (cluster) fills
   if(fill == TRUE) {
-    base <- base + geom_polygon(data = group$path, aes(x = x, y = y, group = group, fill = group), alpha = fill.alpha)
+    base <- base + geom_polygon(data = group$path, aes_string(x = "x", y = "y", group = theGroupName, fill = theGroupName), alpha = fill.alpha)
   }
 
 


### PR DESCRIPTION
When I added facet_wrap to a pipeline after ggradar I had to use facet_wrap(~group) even though the name of the variable I was using was category_of_interest. 

When I tried `test_data %>% ggradar + facet_wrap(~category_of_interest) ` I got:
`Error in `combine_vars()`:
! At least one layer must contain all faceting variables: `category_of_interest`.
* Plot is missing `category_of_interest`
* Layer 1 is missing `category_of_interest`
* Layer 2 is missing `category_of_interest`
* Layer 3 is missing `category_of_interest`
* Layer 4 is missing `category_of_interest`
* Layer 5 is missing `category_of_interest`
* Layer 6 is missing `category_of_interest`
* Layer 7 is missing `category_of_interest`
* Layer 8 is missing `category_of_interest`
* Layer 9 is missing `category_of_interest`
* Layer 10 is missing `category_of_interest`
* Layer 11 is missing `category_of_interest`
* Layer 12 is missing `category_of_interest`
* Layer 13 is missing `category_of_interest`
Run `rlang::last_error()` to see where the error occurred.
`
I added some code so that the name of the grouping variable is preserved so that it can be used in the facet_wrap call. 
I also added a line of code to drop dead levels from the grouping variable. I ran into this problem when I filtered the data on the way into ggradar. This line adds a dependency on forcats. I thought this was okay since forcats is part of the tidyverse.

[make_test_data.R.txt](https://github.com/ricardo-bion/ggradar/files/9789074/make_test_data.R.txt)
