### PR TITLE
Added functionalities to manipulate alpha of lines and points, extended colour palettes.

### DIFF
--- a/R/generate_color_values.R
+++ b/R/generate_color_values.R
@@ -1,0 +1,20 @@
+#' Generate Dynamic Color Values
+#'
+#' This function dynamically generates a vector of color values based on the
+#' number of groups. It uses RColorBrewer for smaller sets of groups and
+#' generates a gradient for larger sets.
+#'
+#' @param num_groups The number of groups for which to generate color values.
+#' @return A character vector of color values.
+#' @importFrom RColorBrewer brewer.pal
+#' @export
+#' @examples
+#' generate_color_values(5)
+#' generate_color_values(20)
+generate_color_values <- function(num_groups) {
+  if (num_groups <= max(brewer.pal.info$maxcolors)) {
+    return(brewer.pal(num_groups, "Set3"))
+  } else {
+    return(colorRampPalette(brewer.pal(8, "Set3"))(num_groups))
+  }
+}

--- a/R/generate_color_values.R
+++ b/R/generate_color_values.R
@@ -12,9 +12,20 @@
 #' generate_color_values(5)
 #' generate_color_values(20)
 generate_color_values <- function(num_groups) {
-  if (num_groups <= max(brewer.pal.info$maxcolors)) {
-    return(brewer.pal(num_groups, "Set3"))
+  # Fallback colors for 1 or 2 groups
+  fallback_colors <- c("#E41A1C", "#377EB8") # Adjust these colors as needed
+  
+  if (num_groups == 1) {
+    # Return the first color if only one group is requested
+    return(fallback_colors[1])
+  } else if (num_groups == 2) {
+    # Return the first two colors for two groups
+    return(fallback_colors[1:2])
+  } else if (num_groups <= max(RColorBrewer::brewer.pal.info$maxcolors)) {
+    # Use RColorBrewer for 3 to max colors
+    return(RColorBrewer::brewer.pal(num_groups, "Set3"))
   } else {
-    return(colorRampPalette(brewer.pal(8, "Set3"))(num_groups))
+    # For more than the maximum supported colors in RColorBrewer, use a color ramp
+    return(colorRampPalette(RColorBrewer::brewer.pal(8, "Set3"))(num_groups))
   }
 }

--- a/R/ggradar.R
+++ b/R/ggradar.R
@@ -292,11 +292,11 @@ ggradar <- function(plot.data,
   #   size = group.line.width
   # )
   if (length(line.alpha) == 1) {
-    base <- base + geom_path(data = group$path, aes(x = .data[["x"]], y = .data[["y"]], group = theGroupName, colour = theGroupName), linewidth = group.line.width, alpha = line.alpha)
+    base <- base + geom_path(data = group$path, aes(x = .data[["x"]], y = .data[["y"]], group = .data[[theGroupName]], colour = .data[[theGroupName]]), linewidth = group.line.width, alpha = line.alpha)
   } else {
     # Assuming line.alpha is a vector with the same length as the number of groups
     # This will apply different alpha values to each line
-    base <- base + geom_path(data = group$path, aes(x = .data[["x"]], y = .data[["y"]], group = theGroupName, colour = theGroupName), linewidth = group.line.width) +
+    base <- base + geom_path(data = group$path, aes(x = .data[["x"]], y = .data[["y"]], group = .data[[theGroupName]], colour = .data[[theGroupName]]), linewidth = group.line.width) +
       scale_alpha_manual(values = line.alpha)
   }
 
@@ -305,18 +305,18 @@ ggradar <- function(plot.data,
   if (draw.points) {
     # Check if point.alpha is a vector or single value
     if (length(point.alpha) == 1) {
-      base <- base + geom_point(data = group$path, aes(x = .data[["x"]], y = .data[["y"]], group = theGroupName, colour = theGroupName), size = group.point.size, alpha = point.alpha)
+      base <- base + geom_point(data = group$path, aes(x = .data[["x"]], y = .data[["y"]], group = .data[[theGroupName]], colour = .data[[theGroupName]]), size = group.point.size, alpha = point.alpha)
     } else {
       # Assuming point.alpha is a vector with the same length as the number of groups
       # This will apply different alpha values to each group
-      base <- base + geom_point(data = group$path, aes(x = .data[["x"]], y = .data[["y"]], group = theGroupName, colour = theGroupName), size = group.point.size) +
+      base <- base + geom_point(data = group$path, aes(x = .data[["x"]], y = .data[["y"]], group = .data[[theGroupName]], colour = .data[[theGroupName]]), size = group.point.size) +
         scale_alpha_manual(values = point.alpha)
     }
   }
 
   # ... + group (cluster) fills
   if (fill == TRUE) {
-    base <- base + geom_polygon(data = group$path, aes(x = .data[["x"]], y = .data[["y"]], group = theGroupName, fill = theGroupName), alpha = fill.alpha)
+    base <- base + geom_polygon(data = group$path, aes(x = .data[["x"]], y = .data[["y"]], group = .data[[theGroupName]], fill = .data[[theGroupName]]), alpha = fill.alpha)
   }
 
 

--- a/R/ggradar.R
+++ b/R/ggradar.R
@@ -40,6 +40,9 @@
 #' @param legend.position position of legend, valid values are "top", "right", "bottom", "left"
 #' @param fill whether to fill polygons
 #' @param fill.alpha if filling polygons, transparency values
+#' @param draw.points whether to draw points
+#' @param point.alpha alpha for points, can be a single value or vector
+#' @param line.alpha alpha for lines, can be a single value or vector
 #'
 #' @import ggplot2
 #' @return a ggplot object
@@ -106,7 +109,6 @@ ggradar <- function(plot.data,
                     legend.position = "left",
                     fill = FALSE,
                     fill.alpha = 0.5,
-                    # New parameters
                     draw.points = TRUE, # Whether to draw points
                     point.alpha = 1, # Alpha for points, can be a single value or vector
                     line.alpha = 1 # Alpha for lines, can be a single value or vector

--- a/R/ggradar.R
+++ b/R/ggradar.R
@@ -73,9 +73,7 @@ ggradar <- function(plot.data,
                     axis.labels = colnames(plot.data)[-1],
                     grid.min = 0, # 10,
                     grid.mid = 0.5, # 50,
-                    grid.max = plot.data |>
-                      select(-1) |>
-                      max(), # the maximum value which other values should be divided by to get a percentage
+                    grid.max = 1, # 100,
                     centre.y = grid.min - ((1 / 9) * (grid.max - grid.min)),
                     plot.extent.x.sf = 1,
                     plot.extent.y.sf = 1.2,
@@ -114,7 +112,7 @@ ggradar <- function(plot.data,
                     line.alpha = 1 # Alpha for lines, can be a single value or vector
 ) {
   plot.data <- as.data.frame(plot.data)
-
+  
   if (!is.factor(plot.data[, 1])) {
     plot.data[, 1] <- as.factor(as.character(plot.data[, 1]))
   }
@@ -135,9 +133,11 @@ ggradar <- function(plot.data,
     stop("plot.data' contains value(s) < centre.y", call. = FALSE)
   }
   if (max(plot.data[, -1]) > grid.max) {
-    stop("'plot.data' contains value(s) > grid.max", call. = FALSE)
+    plot.data[, -1] <- (plot.data[, -1]/max(plot.data[, -1]))*grid.max
+    warning("'plot.data' contains value(s) > grid.max, data scaled to grid.max", call. = FALSE)
   }
-
+  
+  
   ### Convert supplied data into plottable format
   # (a) add abs(centre.y) to supplied plot data
   # [creates plot centroid of 0,0 for internal use, regardless of min. value of y

--- a/R/ggradar.R
+++ b/R/ggradar.R
@@ -342,7 +342,7 @@ ggradar <- function(plot.data,
   if (!is.null(group.colours)) {
     colour_values <- rep(group.colours, length(unique(plot.data[, 1])) / length(group.colours))
   } else {
-    colour_values <- generate_color_values(unique(plot.data[, 1]))
+    colour_values <- generate_color_values(length(unique(plot.data[, 1])))
   }
 
   base <- base +

--- a/R/ggradar.R
+++ b/R/ggradar.R
@@ -118,7 +118,7 @@ ggradar <- function(plot.data,
   if (!is.factor(plot.data[, 1])) {
     plot.data[, 1] <- as.factor(as.character(plot.data[, 1]))
   }
-
+  
   var.names <- colnames(plot.data)[-1] # Short version of variable names
   # axis.labels [if supplied] is designed to hold 'long version' of variable names
   # with line-breaks indicated using \n
@@ -333,10 +333,9 @@ ggradar <- function(plot.data,
   }
 
   if (!is.null(group.colours)) {
-    colour_values <- rep(group.colours, nrow(plot.data) / length(group.colours))
+    colour_values <- rep(group.colours, unique(plot.data[, 1]) / length(group.colours))
   } else {
-    num_groups <- nrow(plot.data)
-    colour_values <- generate_color_values(num_groups)
+    colour_values <- generate_color_values(unique(plot.data[, 1]))
   }
 
   base <- base +


### PR DESCRIPTION
Proposal to add a few functionalities:
1. Add the option to manipulate the alpha values of lines (`line.alpha`) and points (`point.alpha`).
2. Add the option to not draw points at all via `draw.points` parameter.
3. Change the function to not exit when the max values of the provided plot.data exceeds grid.max, but instead scale the provided plot.data to fit grid.max and return a warning.
4. Currently, the function will not work when more than 100 lines are plotted. So I added a helper function to create colour palettes of arbitrary length, or, when colours are provided via `group.colours` parameter, repeat these colours until they match the number of groups present in the data.
5. Changed `size` to `linewidth` in geom_path to fix the warning: 
```
1: Using `size` aesthetic for lines was deprecated in ggplot2 3.4.0.
ℹ Please use `linewidth` instead.
```
6. Changed `aes_string` to the new way of doing non-standard evaluations in ggplot2 https://ggplot2.tidyverse.org/reference/aes_.html